### PR TITLE
Removing literals for the name of the application

### DIFF
--- a/entrypoint/MainAbstract.qml
+++ b/entrypoint/MainAbstract.qml
@@ -3,6 +3,7 @@ import QtQuick.Window 2.12
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.12
 
+
 import "../ui/pages" as Pages
 import "../backend/core"
 
@@ -11,8 +12,7 @@ Window {
     visible: true
     width: 640
     height: 480
-    title: qsTr("DevOps")
-
+    title: Qt.application.name;
     property Component first: null
 
     StackView {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,8 @@ int main(int argc, char *argv[])
     QGuiApplication app(argc, argv);
     app.setOrganizationName(QStringLiteral("Pygoscelis"));
     app.setOrganizationDomain(QStringLiteral("pygoscelis.org"));
-    app.setApplicationName(QStringLiteral("DevOps Console"));
+    app.setApplicationName(QStringLiteral("DevOps"));
+    app.setApplicationDisplayName(QStringLiteral("DevOps Console"));
 
 //    QTranslator translator;
 //    translator.load("DevOps_fr_CA");

--- a/ui/core/Header.qml
+++ b/ui/core/Header.qml
@@ -18,8 +18,8 @@ Item {
     property alias showApplicationMenu: applicationMenu.visible
     property alias showUser: user.visible
     property alias isCanGoBack: back.visible
-    property string mainTitle: qsTr("DevOps Console")
-    property string secondTitle: ""
+    property string mainTitle: Qt.application.displayName
+    property string secondTitle:""
 
     readonly property WSCom com: WSComOne
 

--- a/ui/core/Navigation.qml
+++ b/ui/core/Navigation.qml
@@ -29,7 +29,7 @@ Drawer {
                     Layout.fillWidth: true
                     leftPadding: 10
 
-                    text: qsTr("DevOps Console")
+                    text: Qt.application.displayName
                 }
 
                 ToolButton {

--- a/ui/pages/LoginPage.qml
+++ b/ui/pages/LoginPage.qml
@@ -25,7 +25,7 @@ SimpleLayout {
         anchors.centerIn: parent
 
         Text {
-            text: qsTr("Welcome to the DevOps Console")
+            text: qsTr("Welcome to %1").arg(Qt.application.displayName)
         }
 
         Button {


### PR DESCRIPTION
Replace the litterals "DevOps" and "DevOps Console" to  the QT variables Qt.application.name and Qt.application.displayName respectively.